### PR TITLE
Updates for event timestamps coming from the Timestamped interface

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.tradeshift"
 
 name := "akka-persistence-cassandra-query"
 
-version := "0.1-201511031132"
+version := "0.1-201511031153"
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.tradeshift"
 
 name := "akka-persistence-cassandra-query"
 
-version := "0.1-201511031153"
+version := "0.1-201511031256"
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.tradeshift"
 
 name := "akka-persistence-cassandra-query"
 
-version := "0.1-201210201614"
+version := "0.1-201511031132"
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
@@ -31,7 +31,7 @@ libraryDependencies ++= {
 libraryDependencies += "org.iq80.leveldb" % "leveldb" % "0.7" % "test" // only to make eclipse happy, we're not using it.
 
 // source: https://github.com/jypma/akka-persistence-cassandra/tree/time_index_dev
-libraryDependencies += "com.github.krasserm" %% "akka-persistence-cassandra" % "0.5-jypma-201510201608"
+libraryDependencies += "com.github.krasserm" %% "akka-persistence-cassandra" % "0.5-jypma-201511031129"
 
 libraryDependencies += "com.datastax.cassandra"  % "cassandra-driver-core" % "2.1.8"
 

--- a/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournal.scala
@@ -78,7 +78,7 @@ class CassandraReadJournal(
    * timestamp falls into the same or later time window as [offset].
    * 
    * The returned `EventEnvelope` items have their `offset` set to the event's timestamp,
-   * and `payload` set to the deserialized event instance.
+   * and `payload` set to an instance of {@link EventPayload}
    */
   override def eventsByTag(tag: String, offset: Long): Source[EventEnvelope, Unit] = {
     //FIXME uhm we should be using offset somewhere???

--- a/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournal.scala
@@ -55,7 +55,7 @@ class CassandraReadJournal(
 
   private val journalConfig = new CassandraJournalConfig(system.settings.config.getConfig("cassandra-journal"))
 
-  private val cassandraOps = new CassandraOps(Cassandra(system),
+  private val cassandraOps = new CassandraOps(system, Cassandra(system),
       s"${journalConfig.keyspace}.${journalConfig.table}",
       s"${journalConfig.keyspace}.${journalConfig.metadataTable}",
       s"${journalConfig.keyspace}.${journalConfig.timeIndexTable}",
@@ -77,9 +77,8 @@ class CassandraReadJournal(
    * Returns ALL events added to the journal that implement Timestamped, where their
    * timestamp falls into the same or later time window as [offset].
    * 
-   * The returned `EventEnvelope` items don't have their `offset` member set,
-   * since that would require deserializing all payloads. If you need the individual offset,
-   * deserialize the payloads yourself and just access event.timestamp.
+   * The returned `EventEnvelope` items have their `offset` set to the event's timestamp,
+   * and `payload` set to the deserialized event instance.
    */
   override def eventsByTag(tag: String, offset: Long): Source[EventEnvelope, Unit] = {
     //FIXME uhm we should be using offset somewhere???

--- a/src/main/scala/akka/persistence/cassandra/query/EventPayload.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/EventPayload.scala
@@ -1,0 +1,8 @@
+package akka.persistence.cassandra.query
+
+import akka.util.ByteString
+
+/**
+ * Payload wrapper for an EventEnvelope, allowing access to both the serialized and deserialized form.
+ */
+case class EventPayload[T](serialized: ByteString, deserialized: T)

--- a/src/test/scala/akka/persistence/cassandra/query/CassandraOpsSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/CassandraOpsSpec.scala
@@ -67,7 +67,7 @@ class CassandraOpsSpec extends WordSpec with Matchers with ScalaFutures with Sha
       }
     }
 
-    val ops = new CassandraOps(cassandra, "messages", "metadata", "timeIndex", targetPartitionSize = partitionSize)
+    val ops = new CassandraOps(system, cassandra, "messages", "metadata", "timeIndex", targetPartitionSize = partitionSize)
   }
 
   "CassandraOps.readEvents" when {

--- a/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
@@ -98,11 +98,11 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
         	// we don't validate event.offset, since setting that requires us to deserialize all events.
         	envelope.persistenceId should be ("document-1")
         	envelope.sequenceNr should be (1)
-        	envelope.event shouldBe an[Event]
+        	envelope.event shouldBe an[EventPayload[_]]
 
-        	// by default, akka uses Java serialization, which has serialized our Event.
-        	val content = envelope.event.asInstanceOf[Event]
-        	content.content should be ("change-1")
+        	val content = envelope.event.asInstanceOf[EventPayload[Event]]
+        	content.serialized should not have size(0)
+        	content.deserialized.content should be ("change-1")
         }
 
         system.stop(received.ref)

--- a/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
@@ -51,7 +51,9 @@ object CassandraReadJournalIntegrationSpec {
       |cassandra-snapshot-store.port = 9142
     """.stripMargin)
 
-  case class Event(content: String, timestamp: Instant = Instant.now) extends Timestamped
+  case class Event(content: String, timestamp: Instant = Instant.now) extends Timestamped {
+    def getTimestamp: Long = timestamp.toEpochMilli
+  }
     
   class DocumentActor(probe: ActorRef) extends PersistentActor {
     override def persistenceId = context.self.path.name
@@ -92,14 +94,14 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
         journal.eventsByTag("_all", 0).runWith(Sink.actorRef(received.ref, "complete"))
 
         received.within(1.minute) {
-        	val event = received.expectMsgType[EventEnvelope]
+        	val envelope = received.expectMsgType[EventEnvelope]
         	// we don't validate event.offset, since setting that requires us to deserialize all events.
-        	event.persistenceId should be ("document-1")
-        	event.sequenceNr should be (1)
-        	event.event shouldBe a[akka.util.ByteString]
+        	envelope.persistenceId should be ("document-1")
+        	envelope.sequenceNr should be (1)
+        	envelope.event shouldBe an[Event]
 
         	// by default, akka uses Java serialization, which has serialized our Event.
-        	val content = new ObjectInputStream(event.event.asInstanceOf[akka.util.ByteString].iterator.asInputStream).readObject().asInstanceOf[Event]
+        	val content = envelope.event.asInstanceOf[Event]
         	content.content should be ("change-1")
         }
 
@@ -137,6 +139,48 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
         system.stop(doc)
         Reaper(queries.map(_.ref) :+ doc).futureValue
         journal.shutdown().futureValue
+      }
+      
+      "pick up on changes when multiple changes are made during one time window" in {
+        val probe = TestProbe()
+        val doc = system.actorOf(Props(classOf[DocumentActor], probe.ref), "document-1")
+        val journal = CassandraReadJournal.instance
+
+        // start the event stream
+        val received = TestProbe()
+        journal.eventsByTag("_all", 0).runWith(Sink.actorRef(received.ref, "complete"))
+        
+        def send(i:Int) = { 
+          doc ! s"change-$i"
+          probe.expectMsgType[String] // we know it's persisted once it hits the probe          
+        }
+        
+        send(1)
+        send(2)
+        received.expectMsgType[EventEnvelope]
+        received.expectMsgType[EventEnvelope]
+        Thread.sleep(6000) // poll interval + 1
+        
+        send(1)
+        send(2)
+        received.expectMsgType[EventEnvelope]
+        received.expectMsgType[EventEnvelope]
+        Thread.sleep(6000) // poll interval + 1
+        
+        send(1)
+        send(2)
+        received.expectMsgType[EventEnvelope]
+        received.expectMsgType[EventEnvelope]
+        Thread.sleep(6000) // poll interval + 1
+        
+        send(1)
+        send(2)
+        received.expectMsgType[EventEnvelope]
+        received.expectMsgType[EventEnvelope]
+        Thread.sleep(6000) // poll interval + 1
+        
+        system.stop(doc)
+        journal.shutdown().futureValue        
       }
 
       /*

--- a/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
@@ -101,8 +101,10 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
         	envelope.event shouldBe an[EventPayload[_]]
 
         	val content = envelope.event.asInstanceOf[EventPayload[Event]]
-        	content.serialized should not have size(0)
         	content.deserialized.content should be ("change-1")
+        	
+        	val testedDeserialized = new ObjectInputStream(content.serialized.iterator.asInputStream).readObject().asInstanceOf[Event]
+        	testedDeserialized.content should be ("change-1")
         }
 
         system.stop(received.ref)
@@ -161,20 +163,20 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
         received.expectMsgType[EventEnvelope]
         Thread.sleep(6000) // poll interval + 1
         
-        send(1)
-        send(2)
+        send(3)
+        send(4)
         received.expectMsgType[EventEnvelope]
         received.expectMsgType[EventEnvelope]
         Thread.sleep(6000) // poll interval + 1
         
-        send(1)
-        send(2)
+        send(5)
+        send(6)
         received.expectMsgType[EventEnvelope]
         received.expectMsgType[EventEnvelope]
         Thread.sleep(6000) // poll interval + 1
         
-        send(1)
-        send(2)
+        send(7)
+        send(8)
         received.expectMsgType[EventEnvelope]
         received.expectMsgType[EventEnvelope]
         Thread.sleep(6000) // poll interval + 1


### PR DESCRIPTION
We now actually deserialize events to find out their timestamp. Since we need to do that anyways, we also return both the deserialized event and the original ByteString, so clients can use either.

@domask please review