### PR TITLE
Return events in time window order

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.tradeshift"
 
 name := "akka-persistence-cassandra-query"
 
-version := "0.1-201511231008"
+version := "0.1-201511261419"
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.tradeshift"
 
 name := "akka-persistence-cassandra-query"
 
-version := "0.1-201511261507"
+version := "0.1-201512011153"
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.tradeshift"
 
 name := "akka-persistence-cassandra-query"
 
-version := "0.1-201511031256"
+version := "0.1-201511231008"
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 
@@ -31,7 +31,7 @@ libraryDependencies ++= {
 libraryDependencies += "org.iq80.leveldb" % "leveldb" % "0.7" % "test" // only to make eclipse happy, we're not using it.
 
 // source: https://github.com/jypma/akka-persistence-cassandra/tree/time_index_dev
-libraryDependencies += "com.github.krasserm" %% "akka-persistence-cassandra" % "0.5-jypma-201511031129"
+libraryDependencies += "com.github.krasserm" %% "akka-persistence-cassandra" % "0.5-jypma-201511241013"
 
 libraryDependencies += "com.datastax.cassandra"  % "cassandra-driver-core" % "2.1.8"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "com.tradeshift"
 
 name := "akka-persistence-cassandra-query"
 
-version := "0.1-201511261419"
+version := "0.1-201511261507"
 
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",
     "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % "test",
     "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
+    "com.typesafe.akka" %% "akka-cluster-tools" % akkaVersion,
     "com.typesafe.akka" %% "akka-persistence-query-experimental" % akkaVersion,
     "com.typesafe.akka" %% "akka-http-experimental" % akkaStreamVersion
   )

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,4 +1,5 @@
 akka.persistence.query.journal.cassandra {
   class = "akka.persistence.cassandra.query.CassandraReadJournal"
-  extendedTimeWindowLength = 120 seconds  
+  extendedTimeWindowLength = 120 seconds
+  allowedClockDrift = 5 seconds  
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
 akka.persistence.query.journal.cassandra {
   class = "akka.persistence.cassandra.query.CassandraReadJournal"
-  
+  extendedTimeWindowLength = 120 seconds  
 }

--- a/src/main/scala/akka/persistence/cassandra/query/CassandraOps.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/CassandraOps.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.time.Instant
 import java.util.{ Calendar, TimeZone }
 import scala.collection.AbstractIterator
-import scala.concurrent.duration.{ DurationInt, FiniteDuration }
+import scala.concurrent.duration.{ DurationInt, DurationLong, FiniteDuration }
 import com.typesafe.scalalogging.StrictLogging
 import akka.persistence.cassandra.Cassandra
 import akka.persistence.cassandra.Cassandra.RowMapper
@@ -148,7 +148,11 @@ object CassandraOps {
       persistenceId: String, firstSequenceNrInWindow: Long, partitionNr: Long) {
     private val offsetMin = window_start.toEpochMilli
     private val offsetMax = offsetMin + window_length
-    def isEventInTimeWindow(evt: EventEnvelope) = evt.offset >= offsetMin && evt.offset < offsetMax 
+    def isEventInTimeWindow(evt: EventEnvelope) = evt.offset >= offsetMin && evt.offset < offsetMax
+    def remainingTimeAt(time: Instant): Option[FiniteDuration] = {
+      val offset = time.toEpochMilli
+      if (offset >= offsetMax) None else Some((offsetMax - offset).milliseconds)
+    }
   }
 
   def toYearMonthDay(instant: Instant): Int = {

--- a/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournal.scala
@@ -31,6 +31,7 @@ import akka.stream.scaladsl.Keep
 import scala.concurrent.Future
 import akka.persistence.cassandra.streams.Reaper
 import akka.stream.OverflowStrategy
+import com.typesafe.scalalogging.StrictLogging
 
 /**
  * Implementation of akka persistence read journal, for the akka-persistence-cassandra plugin
@@ -41,7 +42,7 @@ import akka.stream.OverflowStrategy
 class CassandraReadJournal(
     system: ExtendedActorSystem,
     config: Config
-) extends ReadJournalProvider with ReadJournal with EventsByTagQuery {
+) extends ReadJournalProvider with ReadJournal with EventsByTagQuery with StrictLogging {
   import system.dispatcher
 
   override def scaladslReadJournal() = this
@@ -61,16 +62,18 @@ class CassandraReadJournal(
       s"${journalConfig.keyspace}.${journalConfig.timeIndexTable}",
       journalConfig.targetPartitionSize)
 
-  private val realtimeActor = system.actorOf(Props(new IndexEntryPoller(cassandraOps)))
+  val extendedTimeWindowLength = config.getDuration("extendedTimeWindowLength")
+  
+  private val realtimeActor = system.actorOf(Props(new IndexEntryPoller(cassandraOps, extendedTimeWindowLength)))
   private val realtimeIndex = Source.actorRef(16, OverflowStrategy.fail).mapMaterializedValue { actor =>
     realtimeActor.tell(IndexEntryPoller.Subscribe, actor)
-  }.log("realtimeIndex")
+  }
 
   /**
    * Manages the pool of sources that emit real-time events for a given persistenceId.
    */
   private val realtimeEvents = SourcePool(PersistenceIdEventsPoller.Subscribe, 256) { persistenceId: String =>
-    Props(new PersistenceIdEventsPoller(cassandraOps, persistenceId))
+    Props(new PersistenceIdEventsPoller(cassandraOps, persistenceId, extendedTimeWindowLength))
   }
 
   /**
@@ -80,13 +83,16 @@ class CassandraReadJournal(
    * The returned `EventEnvelope` items have their `offset` set to the event's timestamp,
    * and `payload` set to an instance of {@link EventPayload}
    */
+  
   override def eventsByTag(tag: String, offset: Long): Source[EventEnvelope, Unit] = {
-    //FIXME uhm we should be using offset somewhere???
-
-    val (sink, source) = FanoutAndMerge(byPersistenceId, getEvents)
+    val start = indexChronology.latest(
+      indexChronology.beginningOfTime, 
+      Instant.ofEpochMilli(offset) minus journalConfig.timeWindowLength)
+    
+    val (sink, source) = FanoutAndMerge(byTimeWindow, getEvents)
 
     // Combine past index entries and new, real-time ones into a single logical Source
-    RealTime(cassandraOps.pastIndex, realtimeIndex)
+    RealTime(cassandraOps.pastIndex, realtimeIndex, start)
 
       // Filter out duplicate persistenceIds within the same time window
       .transform{ () => new SortedFilterDuplicate[IndexEntry,Instant,String](_.window_start)(_.persistenceId) }
@@ -97,7 +103,7 @@ class CassandraReadJournal(
     source
   }
 
-  private def byPersistenceId(i:IndexEntry) = i.persistenceId
+  private def byTimeWindow(i:IndexEntry) = i.window_start
 
   /**
    * Queries the cassandra index, and then gets the actual events, for the given time window interval, once.
@@ -106,11 +112,20 @@ class CassandraReadJournal(
     cassandraOps.readEvents(persistenceId)(fromSequenceNr, toSequenceNr)
 
   /**
-   * Returns a source that combines all past events for [entry.persistenceId] and then
-   * turns to real-time.
+   * Returns a source that returns the events made for the time window of the given
+   * index entry. If that time window might still be open, the source will pause and become real-time,
+   * until the time window is no longer open. If the time window is historic, the source will  
+   * just complete after returning all the events.
    */
   private def getEvents(entry: IndexEntry): Source[EventEnvelope,Any] = {
-    RealTime(cassandraOps.readEvents(entry.persistenceId), realtimeEvents(entry.persistenceId))
+    //TODO optimize to only read from cassandra, and once, if time window is closed.
+    
+    RealTime(
+      cassandraOps.readEvents(entry.persistenceId), 
+      realtimeEvents(entry.persistenceId), 
+      entry.firstSequenceNrInWindow
+    )
+    .takeWhile(entry.isEventInTimeWindow(_))
   }
 
   /**

--- a/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournal.scala
@@ -75,7 +75,7 @@ class CassandraReadJournal(
    * Manages the pool of sources that emit real-time events for a given persistenceId.
    */
   private val realtimeEvents = SourcePool(PersistenceIdEventsPoller.Subscribe, 256) { persistenceId: String =>
-    Props(new PersistenceIdEventsPoller(cassandraOps, persistenceId, extendedTimeWindowLength))
+    PersistenceIdEventsPoller.props(cassandraOps, persistenceId, extendedTimeWindowLength)
   }
 
   /**

--- a/src/main/scala/akka/persistence/cassandra/query/IndexEntryPoller.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/IndexEntryPoller.scala
@@ -20,7 +20,7 @@ class IndexEntryPoller(
     cassandraOps: CassandraOps,
 
     // longest time window ever stored + allowed clock drift
-    extendedTimeWindowLength:Duration = Duration.ofSeconds(120),
+    extendedTimeWindowLength:Duration,
 
     pollDelay:FiniteDuration = 5.seconds,
 
@@ -89,7 +89,7 @@ class IndexEntryPoller(
   def entriesToRemember(threshold: Instant, candidates: TreeSet[IndexEntry]): Set[IndexEntry] = {
     candidates.from(IndexEntry(window_start = threshold, persistenceId = "",
         // the subsequent fields are not used for sorting, but are required to instantiate an IndexEntry
-        yearMonthDay = 0, firstSequenceNrInWindow = 0, partitionNr = 0))
+        window_length = 0, yearMonthDay = 0, firstSequenceNrInWindow = 0, partitionNr = 0))
   }
 
   /**

--- a/src/main/scala/akka/persistence/cassandra/query/PersistenceIdEventsPoller.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/PersistenceIdEventsPoller.scala
@@ -18,7 +18,7 @@ class PersistenceIdEventsPoller(
     cassandraOps: CassandraOps,
     persistenceId: String,
     // longest time window ever stored + allowed clock drift
-    extendedTimeWindowLength:Duration = Duration.ofSeconds(120),
+    extendedTimeWindowLength:Duration,
     pollDelay: FiniteDuration = 5.seconds,
     nowFunc: => Instant = Instant.now,
     // Maximum queue size should be the amount of memory we want to spend on slow real-time consumers.

--- a/src/main/scala/akka/persistence/cassandra/query/SourcePool.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/SourcePool.scala
@@ -48,6 +48,7 @@ class SourcePool[T,K](factory: K => Props, subscribeMessage: Any, bufferSize: In
   private class ManagerActor extends Actor {
     val running = collection.mutable.Map.empty[K,ActorRef]
     val keyForActor = collection.mutable.Map.empty[ActorRef,K]
+    val subscribers = collection.mutable.Map.empty[ActorRef,Set[ActorRef]].withDefaultValue(Set.empty)
 
     def receive = {
       case AddSubscription(key) =>
@@ -58,8 +59,10 @@ class SourcePool[T,K](factory: K => Props, subscribeMessage: Any, bufferSize: In
           actor
         })
         worker.tell(subscribeMessage, sender)
+        subscribers(worker) += sender
 
       case Terminated(actor) =>
+        subscribers(actor).foreach(context.stop)
         running.remove(keyForActor(actor))
     }
   }

--- a/src/main/scala/akka/persistence/cassandra/query/SourcePool.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/SourcePool.scala
@@ -52,7 +52,7 @@ class SourcePool[T,K](factory: K => Props, subscribeMessage: Any, bufferSize: In
     def receive = {
       case AddSubscription(key) =>
         val worker = running.getOrElseUpdate(key, {
-          val actor = context.actorOf(factory(key), key.toString)
+          val actor = context.actorOf(factory(key))
           context.watch(actor)
           keyForActor(actor) = key
           actor

--- a/src/main/scala/akka/persistence/cassandra/streams/FanoutAndMerge.scala
+++ b/src/main/scala/akka/persistence/cassandra/streams/FanoutAndMerge.scala
@@ -191,7 +191,9 @@ object FanoutAndMerge {
 
 	  case object LogQueue
 	  import context.dispatcher
-	  val debugTimer = context.system.scheduler.schedule(200.milliseconds, 200.milliseconds, self, LogQueue)
+	  if (log.isDebugEnabled) {
+	    val debugTimer = context.system.scheduler.schedule(200.milliseconds, 200.milliseconds, self, LogQueue)	    
+	  }
 	  
 	  out ! Register(self)
 

--- a/src/main/scala/akka/persistence/cassandra/streams/rt/Chronology.scala
+++ b/src/main/scala/akka/persistence/cassandra/streams/rt/Chronology.scala
@@ -4,5 +4,7 @@ trait Chronology[Elem,Time] {
   def getTime(elem: Elem): Time
   def beginningOfTime: Time
   def endOfTime: Time
+  /** Returns whether A is before B */
   def isBefore(a: Time, b: Time): Boolean
+  def latest(a: Time, b: Time): Time = if (isBefore(a, b)) b else a 
 }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,36 @@
+akka {
+  loglevel = "DEBUG"
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  
+  actor {
+    provider = "akka.cluster.ClusterActorRefProvider"
+  }
+  
+  remote {
+    log-remote-lifecycle-events = off
+    netty.tcp {
+      hostname = ${clustering.ip}
+      port = ${clustering.port}
+    }
+  }
+  
+  cluster {
+    seed-nodes = [
+      "akka.tcp://"${clustering.name}"@"${clustering.seed-ip}":"${clustering.seed-port}
+    ]
+  }
+}
+
+clustering {
+  ip = "127.0.0.1"      // The IP address to bind akka clustering to
+  ip = ${?CLUSTER_IP}
+  port = 3325           // The port to bind akka clustering to
+  port = ${?CLUSTER_PORT}
+  seed-ip = "127.0.0.1"
+  seed-ip = ${?CLUSTER_IP}
+  seed-ip = ${?SEED_PORT_3325_TCP_ADDR}
+  seed-port = 3325
+  seed-port = ${?SEED_PORT_3325_TCP_PORT}
+  name = akka-persistence-query-test
+}

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -15,6 +15,7 @@
   <logger name="akka.persistence.cassandra.ResultSetActorPublisher"><level value="WARN" /></logger>
   <logger name="akka.persistence.cassandra.query.CassandraOps"><level value="WARN" /></logger>
   <logger name="akka.persistence.cassandra.streams.rt.RealTime$"><level value="WARN" /></logger>
+  <logger name="akka.persistence.cassandra.streams.FanoutAndMerge$FanoutActor"><level value="WARN" /></logger> 
   
   <root>
     <priority value="DEBUG" />

--- a/src/test/scala/akka/persistence/cassandra/query/CassandraOpsSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/CassandraOpsSpec.scala
@@ -73,7 +73,7 @@ class CassandraOpsSpec extends WordSpec with Matchers with ScalaFutures with Sha
   "CassandraOps.readEvents" when {
     "having events stored across several partitions" should {
       "read all events and then complete" in new Fixture(
-          index = Seq(IndexEntry(20151013, Instant.ofEpochSecond(1444727657l), "doc-1", 1, 0)),
+          index = Seq(IndexEntry(20151013, Instant.ofEpochSecond(1444727657l), 60000, "doc-1", 1, 0)),
           events = Seq(EventEnvelope(1444727657l, "doc-1", 1, 1),
                        EventEnvelope(1444727657l, "doc-1", 2, 2),
                        EventEnvelope(1444727657l, "doc-1", 3, 3),
@@ -98,7 +98,7 @@ class CassandraOpsSpec extends WordSpec with Matchers with ScalaFutures with Sha
       // polling from all calls to .readEvents() anyways.
       
       "stop reading when it sees a gap" in new Fixture(
-          index = Seq(IndexEntry(20151013, Instant.ofEpochSecond(1444727657l), "doc-1", 1, 0)),
+          index = Seq(IndexEntry(20151013, Instant.ofEpochSecond(1444727657l), 60000, "doc-1", 1, 0)),
           events = Seq(EventEnvelope(1444727657l, "doc-1", 1, 1),
                        EventEnvelope(1444727657l, "doc-1", 3, 3))
         ) {

--- a/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
@@ -235,8 +235,8 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
         Thread.sleep(1000) // time window is 1 second
         send(3)
         Thread.sleep(1000) // time window is 1 second
-        send(4)
         val offset = System.currentTimeMillis()
+        send(4)
         
         Thread.sleep(1000) // time window is 1 second
         send(5)

--- a/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
@@ -44,6 +44,7 @@ object CassandraReadJournalIntegrationSpec {
       |akka.persistence.publish-confirmations = on
       |akka.persistence.publish-plugin-commands = on
       |akka.test.single-expect-default = 10s
+      |akka.persistence.query.journal.cassandra.allowedClockDrift = 1s
       |cassandra-journal.max-partition-size = 5
       |cassandra-journal.max-result-size = 3
       |cassandra-journal.port = 9142
@@ -147,6 +148,7 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
           val q = queries(i)
           q.within(1.minute) {
             for (j <- 0 to messageCount) {
+              //println(s"*** Waiting for query $i, message $j") 
             	q.expectMsgType[EventEnvelope]
             }
           }

--- a/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalIntegrationSpec.scala
@@ -47,11 +47,12 @@ object CassandraReadJournalIntegrationSpec {
       |cassandra-journal.max-partition-size = 5
       |cassandra-journal.max-result-size = 3
       |cassandra-journal.port = 9142
-      |cassandra-journal.timeWindowLength = 10s
+      |cassandra-journal.time-window-length = 1s
       |cassandra-snapshot-store.port = 9142
     """.stripMargin)
 
   case class Event(content: String, timestamp: Instant = Instant.now) extends Timestamped {
+    println(s"*** Created Event at ${timestamp.toEpochMilli()}") 
     def getTimestamp: Long = timestamp.toEpochMilli
   }
     
@@ -76,13 +77,35 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
   implicit val m = ActorMaterializer()
 
   "the CassandraReadJournal" when {
+    
+    class Fixture {
+      val probe = TestProbe()
+      val doc = system.actorOf(Props(classOf[DocumentActor], probe.ref))
+      val persistenceId = doc.path.name
+      val journal = CassandraReadJournal.instance
+      def shutdown() {
+        system.stop(doc)
+        Reaper(doc).futureValue
+        journal.shutdown().futureValue
+      }
+    }
+    
+    def fixture(code: Fixture => Unit) = {
+      val f = new Fixture()
+      try {
+        code(f)
+      } finally {
+        f.shutdown()
+      }
+    }
+    
     "listening on an empty database" should {
 
-      "pick up a single event and send it to a single running query" in {
+      "pick up a single event and send it to a single running query" in fixture { f =>
+        import f._
+        
         val testStart = System.currentTimeMillis()
 
-        val probe = TestProbe()
-        val doc = system.actorOf(Props(classOf[DocumentActor], probe.ref), "document-1")
         doc ! "change-1"
         probe.within(1.minute) {
           probe.expectMsg("change-1") // we know it's persisted once it hits the probe
@@ -90,13 +113,12 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
 
         val received = TestProbe()
 
-        val journal = CassandraReadJournal.instance
         journal.eventsByTag("_all", 0).runWith(Sink.actorRef(received.ref, "complete"))
 
         received.within(1.minute) {
         	val envelope = received.expectMsgType[EventEnvelope]
         	// we don't validate event.offset, since setting that requires us to deserialize all events.
-        	envelope.persistenceId should be ("document-1")
+        	envelope.persistenceId should be (persistenceId)
         	envelope.sequenceNr should be (1)
         	envelope.event shouldBe an[EventPayload[_]]
 
@@ -106,21 +128,14 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
         	val testedDeserialized = new ObjectInputStream(content.serialized.iterator.asInputStream).readObject().asInstanceOf[Event]
         	testedDeserialized.content should be ("change-1")
         }
-
-        system.stop(received.ref)
-        system.stop(doc)
-        Reaper(received.ref,doc).futureValue
-        journal.shutdown().futureValue
       }
 
-      "eventually send all generated events to all clients" in {
-        val probe = TestProbe()
-        val doc = system.actorOf(Props(classOf[DocumentActor], probe.ref), "document-1")
-        val journal = CassandraReadJournal.instance
-
-        val messageCount = 100
+      "eventually send all generated events to all clients" in fixture { f =>
+        import f._ 
+  
+        val messageCount = 40
         val queries = for (i <- 0 to messageCount) yield {
-          Thread.sleep(10)
+          Thread.sleep(200)
           doc ! s"change-{i}"
           probe.expectMsgType[String] // we know it's persisted once it hits the probe
           val received = TestProbe()
@@ -130,24 +145,44 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
 
         for (i <- 0 to messageCount) {
           val q = queries(i)
-          for (j <- 0 to messageCount) {
-            q.within(1.minute) {
+          q.within(1.minute) {
+            for (j <- 0 to messageCount) {
             	q.expectMsgType[EventEnvelope]
             }
           }
         }
 
         for (i <- 0 to messageCount) system.stop(queries(i).ref)
-        system.stop(doc)
-        Reaper(queries.map(_.ref) :+ doc).futureValue
-        journal.shutdown().futureValue
+        Reaper(queries.map(_.ref)).futureValue
       }
       
-      "pick up on changes when multiple changes are made during one time window" in {
-        val probe = TestProbe()
-        val doc = system.actorOf(Props(classOf[DocumentActor], probe.ref), "document-1")
-        val journal = CassandraReadJournal.instance
+      "keep sending events to a query as time windows progress" in fixture { f =>
+        import f._ 
+  
+        val received = TestProbe()
+        journal.eventsByTag("_all", 0).runWith(Sink.actorRef(received.ref, "complete"))
+        
+        val messageCount = 30
+        for (i <- 0 to messageCount) {
+          Thread.sleep(100)
+          doc ! s"change-{i}"
+          probe.expectMsgType[String] // we know it's persisted once it hits the probe
+        }
 
+        received.within(1.minute) {
+          for (i <- 0 to messageCount) {
+            println(s"*** Waiting for message $i") 
+          	received.expectMsgType[EventEnvelope]
+          }
+        }
+
+        system.stop(received.ref)
+        Reaper(received.ref).futureValue
+      }
+      
+      "pick up on changes when multiple changes are made during one time window" in fixture { f =>
+        import f._
+        
         // start the event stream
         val received = TestProbe()
         journal.eventsByTag("_all", 0).runWith(Sink.actorRef(received.ref, "complete"))
@@ -180,18 +215,42 @@ class CassandraReadJournalIntegrationSpec extends TestKit(ActorSystem("test", co
         received.expectMsgType[EventEnvelope]
         received.expectMsgType[EventEnvelope]
         Thread.sleep(6000) // poll interval + 1
-        
-        system.stop(doc)
-        journal.shutdown().futureValue        
       }
+    }
 
-      /*
-      "discover real-time events as they are added, across partition boundaries" in {
-        pending
+    "answering a query with offset" should {
+      "return only events from time windows at or after the offset" in fixture { f =>
+        import f._
+        
+        def send(i:Int) = { 
+          doc ! s"change-$i"
+          probe.expectMsgType[String] // we know it's persisted once it hits the probe          
+        }
+        
+        send(1)
+        Thread.sleep(1000) // time window is 1 second
+        send(2)
+        Thread.sleep(1000) // time window is 1 second
+        send(3)
+        Thread.sleep(1000) // time window is 1 second
+        send(4)
+        val offset = System.currentTimeMillis()
+        
+        Thread.sleep(1000) // time window is 1 second
+        send(5)
+        Thread.sleep(1000) // time window is 1 second
+        send(6)
+        Thread.sleep(1000) // time window is 1 second
+        
+        val received = TestProbe()
+        journal.eventsByTag("_all", offset).runWith(Sink.actorRef(received.ref, "complete"))
+        val first = received.expectMsgType[EventEnvelope]
+        first.sequenceNr should be (4)
+        val second = received.expectMsgType[EventEnvelope]
+        second.sequenceNr should be (first.sequenceNr + 1)
+        val third = received.expectMsgType[EventEnvelope]
+        third.sequenceNr should be (second.sequenceNr + 1)
       }
-      * /
-      */
     }
   }
-
 }

--- a/src/test/scala/akka/persistence/cassandra/query/IndexEntryPollerSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/IndexEntryPollerSpec.scala
@@ -25,7 +25,7 @@ class IndexEntryPollerSpec extends WordSpec with Matchers with ScalaFutures with
     val      startOfTomorrow = Instant.ofEpochSecond(1420156800) // Thu, 01 Jan 2015 00:00:00 GMT
 
     def mkIndexEntry(windowStart: Instant, persistenceId: String) =
-      IndexEntry(IndexEntryPoller.toYearMonthDay(windowStart), windowStart, persistenceId, 0, 0)
+      IndexEntry(IndexEntryPoller.toYearMonthDay(windowStart), windowStart, 60000, persistenceId, 0, 0)
 
     class Fixture(
       val initialContent: Set[IndexEntry] = Set.empty,

--- a/src/test/scala/akka/persistence/cassandra/streams/FanoutAndMergeSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/streams/FanoutAndMergeSpec.scala
@@ -8,57 +8,79 @@ import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.OverflowStrategy
 import akka.testkit.TestProbe
 import akka.stream.scaladsl.Keep
+import scala.util.Random
 
 class FanoutAndMergeSpec extends WordSpec with Matchers with ScalaFutures with SharedActorSystem {
   implicit val patience = PatienceConfig(timeout = Span(10, Seconds)) // actual run-time on 4-core machine: 1 second
+  def toSequence[T] = Sink.fold[Seq[T],T](Seq.empty)((seq, elem) => seq :+ elem)
 
   "The FanoutAndMerge operation" should {
-    case class InElem(i:Int)
-    case class OutElem(s:String)
+    case class InElem(key: Int, value: String) 
 
-    def getKey(elem: InElem) = elem.i
-    def getSource(elem: InElem) = Source(elem.i until (elem.i + 199)).concat(Source.single {
-      Thread.sleep(10) // we sleep a bit on the last element to simulate sub-streams that take a bit of time to complete.
-      elem.i + 200
-    })
+    def getKey(elem: InElem) = elem.key
 
     "eventually forward and receive all elements in all generated nested sources" in {
+      def getSource(elem: InElem) = Source(elem.key until (elem.key + 200))
+      
       val (sink, source) = FanoutAndMerge(getKey, getSource)
 
-      Source(1 to 200).map(i => InElem(i * 200)).runWith(sink)
+      Source(1 to 200).map(i => InElem(i * 200, i.toString)).runWith(sink)
       val count = source.runWith(Sink.fold(0)((i, elem) => i + 1)).futureValue
 
       count should be (40000)
     }
 
-    "only process input elements once when they yield the same key" in {
+    "process all nested sources for one key before continuing with the next key" in {
+      def getSource(elem: InElem) = Source.repeat(elem.key).map { i =>
+        Thread.sleep(Random.nextInt(5))
+        i
+      }.take(100)
       val (sink, source) = FanoutAndMerge(getKey, getSource)
-
-      Source(List(1,1,1)).map(i => InElem(i * 200)).runWith(sink)
-      val count = source.runWith(Sink.fold(0)((i, elem) => i + 1)).futureValue
-
-      count should be (200)
+      Source(List(1,1,1,1,1,1,1,1,1,1,2)).map(i => InElem(i, i.toString)).runWith(sink)
+      
+      val result = source.runWith(toSequence).futureValue
+      result should have size(11 * 100)
+      result should contain inOrderOnly(1,2)
+      result(999) should be (1)
+      result(1000) should be (2)
     }
-
-    "re-process input elements with the same key, after their nested source has completed, and then end once the source completes" in {
-      val trigger = Source.actorRef(1, OverflowStrategy.fail)
+    
+    "process nested sources with the same key out of order" in {
+      def getSource(elem: InElem) = Source.repeat(elem.value).map { i =>
+        Thread.sleep(Random.nextInt(5))
+        i
+      }.take(100)
       val (sink, source) = FanoutAndMerge(getKey, getSource)
-      val received = TestProbe()
-      source.runWith(Sink.actorRef(received.ref, "completed"))
-      val triggerActor = trigger.toMat(sink)(Keep.left).run()
-
-      triggerActor ! InElem(1)
-      for (i <- 1 to 200) received.expectMsgType[Int]
-
-      // the source must have completed since we've received the last element. Sleep a bit to be sure.
-      Thread.sleep(10)
-
-      triggerActor ! InElem(1)
-      for (i <- 1 to 200) received.expectMsgType[Int]
-
-      // let's end the stream.
-      system.stop(triggerActor)
-      received.expectMsg("completed")
+      Source(List(InElem(1,"one"), InElem(1,"two"), InElem(1,"three"), InElem(1,"four"))).runWith(sink)
+      
+      val result = source.runWith(toSequence).futureValue
+      result should have size(4 * 100)
+      result should contain only ("one", "two", "three", "four")
+      result should not contain inOrderOnly ("one", "two", "three", "four")
+      result.filter(_ == "one") should have size(100)
+      result.filter(_ == "two") should have size(100)
+      result.filter(_ == "three") should have size(100)
+      result.filter(_ == "four") should have size(100)
+    }
+    
+    "resume processing after reaching a state where all substreams have completed and nothing was queued" in {
+      def getSource(elem: InElem) = Source.single(elem)
+      val (sink, source) = FanoutAndMerge(getKey, getSource)
+      val trigger = Source.actorRef[InElem](1, OverflowStrategy.fail).toMat(sink)(Keep.left).run()
+      val receiver = TestProbe()
+      source.runWith(Sink.actorRef(receiver.ref, "done"))
+      
+      trigger ! InElem(1,"1.1")
+      trigger ! InElem(1,"1.2")
+      trigger ! InElem(1,"1.3")
+      receiver.expectMsgType[InElem].key should be (1)
+      receiver.expectMsgType[InElem].key should be (1)
+      receiver.expectMsgType[InElem].key should be (1)
+      
+      Thread.sleep(100) // Allow the intermediate FanoutActor to discover all sub-streams have completed
+      
+      trigger ! InElem(2,"2.1")
+      receiver.expectMsgType[InElem].key should be (2)
     }
   }
 }

--- a/src/test/scala/akka/persistence/cassandra/test/SharedActorSystem.scala
+++ b/src/test/scala/akka/persistence/cassandra/test/SharedActorSystem.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.actor.Actor
 import akka.actor.Props
+import com.typesafe.config.ConfigFactory
 
 /**
  * Marks a spec that is to OK to run in a shared actor system, so it can run concurrently with other specs.
@@ -14,7 +15,8 @@ trait SharedActorSystem {
 }
 
 object SharedActorSystem {
-  private implicit val system = ActorSystem()
+  private val config = ConfigFactory.load();
+  private implicit val system = ActorSystem(config.getString("clustering.name"), config)
   private implicit val materializer = ActorMaterializer()
 
   private class DummyActor extends Actor {


### PR DESCRIPTION
Implementation runs a query per persistenceId per time window, and stops reading once the event's time is no longer in the time window. A future optimization might keep N open queries around,  resuming them as time windows progress.

@tom-williams @domask please review.

Requires https://github.com/jypma/akka-persistence-cassandra/pull/1 to know the actual length of time windows.